### PR TITLE
[Naitei] ft:Update_Status_Bill_Admin

### DIFF
--- a/app/assets/stylesheets/_variable.scss
+++ b/app/assets/stylesheets/_variable.scss
@@ -73,8 +73,6 @@ $box-shadow-color: rgba(0, 0, 0, 0.1);
 $secondary-btn-bg: #6c757d;
 $secondary-btn-hover-bg: #5a6268;
 $my-cart-row-a: rgba(86, 172, 89, 0.10);
-$primary-color: #6c757d;
-$primary-color-hover: #5a6268;
 $table-header-background: #f8f9fa;
 $table-border-color: #dee2e6;
 $hover-color: #ddd;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -454,11 +454,11 @@
   }
 
   h1 {
-    margin-left: 370px;
+    margin-left: 20%;
   }
 
   .nav-link {
-    margin-left: 370px;
+    margin-left: 20%;
   }
 
   .body__menu {
@@ -968,6 +968,7 @@
     th, td {
       padding: 12px;
       text-align: left;
+      padding-left: 4px;
     }
 
     th {

--- a/app/controllers/admin/bills_controller.rb
+++ b/app/controllers/admin/bills_controller.rb
@@ -1,14 +1,36 @@
 class Admin::BillsController < AdminController
+  before_action :find_bill, only: %i(show update_status)
   def index
     @pagy, @bills = pagy(Bill.order(created_at: :desc),
                          items: Settings.page_size)
   end
 
-  def show
+  def show; end
+
+  def update_status
+    if @bill.update bill_params
+      flash.now[:success] = t "admin.view.bill_updated_successfully"
+      respond_to do |format|
+        format.turbo_stream
+        format.html{redirect_to @bill}
+      end
+    else
+      flash.now[:danger] = t "admin.view.bill_update_failed"
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def find_bill
     @bill = Bill.find_by(id: params[:id])
     return if @bill
 
     flash[:danger] = t "bills.not_found"
     redirect_to admin_bills_path
+  end
+
+  def bill_params
+    params.require(:bill).permit(:status)
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -17,3 +17,5 @@ Turbo.session.drive = false
 //= require i18n.js
 
 //= require i18n/translations
+import "controllers"
+import "@hotwired/turbo-rails"

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -2,6 +2,6 @@ import { Controller } from '@hotwired/stimulus'
 
 export default class extends Controller {
   connect() {
-    this.element.textContent = "Hello World!"
+    this.element.textContent = 'Hello World!'
   }
 }

--- a/app/models/bill.rb
+++ b/app/models/bill.rb
@@ -10,10 +10,16 @@ class Bill < ApplicationRecord
     completed: 3,
     cancelled: 4
   }
+  STATUSES = statuses.keys.map do |status|
+    [I18n.t("admin.view.statuses.#{status}"),
+   status]
+  end
   belongs_to :user
   belongs_to :voucher, optional: true
   has_many :bill_details, dependent: :destroy
   has_many :products, through: :bill_details
+
+  validates :status, inclusion: {in: statuses.keys}
   delegate :name, to: :user, prefix: true
   delegate :discount, to: :voucher, prefix: true, allow_nil: true
 

--- a/app/views/admin/bills/_bill.html.erb
+++ b/app/views/admin/bills/_bill.html.erb
@@ -4,7 +4,14 @@
   <td><%= bill.address %></td>
   <td><%= bill.phone_number %></td>
   <td><%= discount_to_percentage(bill.voucher_discount) %></td>
-  <td><%= bill.status %></td>
+  <td>
+    <%= turbo_frame_tag dom_id(bill, :status) do %>
+      <%= form_with(model: bill, url: update_status_admin_bill_path(bill), method: :patch, data: { turbo_frame: dom_id(bill, :status) }) do |form| %>
+        <%= form.select :status, Bill::STATUSES, { include_blank: "Select Status" }, class: 'form-control' %>
+        <%= form.submit 'Update Status', class: 'btn btn-primary mt-2' %>
+      <% end %>
+    <% end %>
+  </td>
   <td><%= number_to_currency(bill.total, unit: Settings.money_unit_vnd, precision: Settings.digits_0, format: Settings.currency_format) %></td>
   <td><%= number_to_currency(bill.total_after_discount, unit: Settings.money_unit_vnd, precision: Settings.digits_0, format: Settings.currency_format) %></td>
   <td><%= format_expired_at(bill.expired_at) %></td>

--- a/app/views/admin/bills/update_status.turbo_stream.erb
+++ b/app/views/admin/bills/update_status.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace dom_id(@bill, :status) do %>
+  <td id="<%= dom_id(@bill, :status) %>">
+    <%= I18n.t("admin.view.statuses.#{@bill.status}") %>
+  </td>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -200,6 +200,7 @@ en:
       quantity: "Quantity"
       price: "Price"
       actions: "Actions"
+      update: "Update"
       id: "ID"
       bill_details:
         title: "Bill Details #%{id}"
@@ -220,6 +221,12 @@ en:
         updated_at: "Updated At"
         actions: "Actions"
         not_found: "Bill not found"
+      statuses:
+        wait_for_pay: "Waiting for Payment"
+        wait_for_prepare: "Waiting for Preparation"
+        wait_for_delivery: "Waiting for Delivery"
+        completed: "Completed"
+        cancelled: "Cancelled"
     voucher:
       index:
         title: "Voucher List"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -225,6 +225,16 @@ vi:
         updated_at: "Ngày Cập Nhật"
         actions: "Hành Động"
         not_found: "Không tìm thấy hóa đơn"
+      update: "Cập nhật"
+      bill_details:
+        title: "Chi tiết hóa đơn #%{id}"
+        bill_items: "Các mục trong hóa đơn"
+      statuses:
+        wait_for_pay: "Đang Chờ Thanh Toán"
+        wait_for_prepare: "Đang Chuẩn Bị"
+        wait_for_delivery: "Đang Giao Hàng"
+        completed: "Hoàn Thành"
+        cancelled: "Đã Hủy"
     voucher:
       index:
         title: "Danh sách Voucher"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,11 @@ Rails.application.routes.draw do
       resources :products
       resources :bills, only: [:index, :show]
       resources :cart_details
+      resources :bills, only: [:index, :show, :update] do
+        member do
+          patch :update_status
+        end
+      end
       resources :vouchers
     end
   end


### PR DESCRIPTION
## Related Tickets
- ticket redmine

## WHAT (optional)
- Change number items `completed/total` in admin page.

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.



## Evidence (Screenshot or Video)

https://github.com/user-attachments/assets/f38a2b59-1563-4950-add3-87d30ec5ffcb


![image](https://github.com/user-attachments/assets/571cce4f-b66a-4bfb-a532-93d932a2b165)







## Notes (Kiến thức tìm hiểu thêm)
