### PR TITLE
[Naitei][Bug] Update negative quantity of products in cart

### DIFF
--- a/app/controllers/cart_controller.rb
+++ b/app/controllers/cart_controller.rb
@@ -7,13 +7,12 @@ class CartController < ApplicationController
 
   def create
     quantity = params[:quantity].to_i
-    handle_add_failed and return unless check_quantity quantity
+    handle_add_failed and return unless check_quantity(quantity) &&
+                                        check_remain(@product
+                                          .remain_quantity, quantity)
 
     current_cart_detail = @cart_details.find_by(product_id: @product.id)
     if current_cart_detail
-      handle_add_failed and return unless
-      check_remain current_cart_detail.remain_quantity, quantity
-
       new_quantity = current_cart_detail.quantity + quantity
       current_cart_detail.update(quantity: new_quantity)
     else
@@ -29,8 +28,9 @@ class CartController < ApplicationController
 
   def update
     quantity = params[:quantity].to_i
-    handle_update_failed and return unless
-    check_remain @current_cart_detail.remain_quantity, quantity
+    handle_update_failed and return unless check_quantity_update(quantity) &&
+                                           check_remain(@current_cart_detail
+                                            .remain_quantity, quantity)
 
     handle_update_success @current_cart_detail, quantity
   end
@@ -76,6 +76,10 @@ class CartController < ApplicationController
     quantity > Settings.digit_0
   end
 
+  def check_quantity_update quantity
+    quantity >= Settings.digit_0
+  end
+
   def handle_add_success
     flash[:success] = t "cart.add_success"
     redirect_to cart_path(current_user)
@@ -93,7 +97,7 @@ class CartController < ApplicationController
   end
 
   def check_remain remain, quantity
-    quantity < remain
+    quantity <= remain
   end
 
   def handle_update_success current_cart_detail, quantity


### PR DESCRIPTION
## Related Tickets
[[User] Cập nhật giỏ hàng có thể nhập số lượng là số âm](https://edu-redmine.sun-asterisk.vn/issues/79563?issue_count=33&issue_position=12&next_issue_id=78824&prev_issue_id=78441)

## WHAT (optional)
- Change number items `completed/total` in admin page.

## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
[Screencast from 2024-08-13 10-51-09.webm](https://github.com/user-attachments/assets/2e0f4097-d888-4b27-807e-33807ab1357c)
![passrubocop_fix_bug_update_cart](https://github.com/user-attachments/assets/58853912-c5f7-4297-8259-806434e736bb)

## Notes (Kiến thức tìm hiểu thêm)
